### PR TITLE
Add cirrus-ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,11 @@
+container:
+  image: cirrusci/flutter:latest
+
+test_task:
+  pub_cache:
+    folder: ~/.pub-cache
+  test_script: flutter test -machine > report.json
+  always:
+    report_artifacts:
+      path: report.json
+      format: flutter

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ container:
 test_task:
   pub_cache:
     folder: ~/.pub-cache
-  test_script: flutter test --machine > report.json
+  test_script: flutter test --reporter json > report.json
   always:
     report_artifacts:
       path: report.json

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ container:
 test_task:
   pub_cache:
     folder: ~/.pub-cache
-  test_script: flutter test -machine > report.json
+  test_script: flutter test --machine > report.json
   always:
     report_artifacts:
       path: report.json

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: cirrusci/flutter:latest
+  image: cirrusci/flutter:2.0.5
 
 test_task:
   pub_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ container:
 test_task:
   pub_cache:
     folder: ~/.pub-cache
-  test_script: flutter test --reporter json > report.json
+  test_script: flutter test --reporter json | grep '^{.*}$' > report.json
   always:
     report_artifacts:
       path: report.json

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,9 @@ container:
 test_task:
   pub_cache:
     folder: ~/.pub-cache
-  test_script: flutter test --reporter json | grep '^{.*}$' > report.json
+  test_script: |
+    flutter pub get
+    flutter test --reporter json > report.json
   always:
     report_artifacts:
       path: report.json


### PR DESCRIPTION
Cirrus CIを使って、自動的にテストが行われるようにします。

## ハマった
CIでの`flutter test --machine`を実行したときにjsonのレポートの前に↓のような出力がされて、report.jsonに紛れ込み、フォーマットを壊していました…。

```console
Running "flutter pub get" in cirrus-ci-build...                    812ms
{"protocolVersion":"0.1.1","runnerVersion":null,"pid":61,"type":"start","time":0}
# (省略)
```

テストの前に`flutter pub get`を行うことで、回避しました。

## 参照
- [Examples - Cirrus CI#Flutter](https://cirrus-ci.org/examples/#flutter)