### PR TITLE
+ボタンで新規作成ページを表示する

### DIFF
--- a/lib/topic_list_page.dart
+++ b/lib/topic_list_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_conversation_memo/topic_page.dart';
 
 class TopicListPage extends StatelessWidget {
   @override
@@ -18,13 +19,20 @@ class TopicListPage extends StatelessWidget {
           ),
         ),
         floatingActionButton: FloatingActionButton(
-          onPressed: _createNewTopic,
+          onPressed: () {
+            _createNewTopic(context);
+          },
           tooltip: 'Add new topic',
           child: Icon(Icons.add),
         ));
   }
 
-  void _createNewTopic() {
+  void _createNewTopic(BuildContext context) {
     // nop
+    Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => TopicPage(),
+        ));
   }
 }

--- a/lib/topic_page.dart
+++ b/lib/topic_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class TopicPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('会話ネタ帳'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              'ネタ新規追加',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/topic_list_page_test.dart
+++ b/test/topic_list_page_test.dart
@@ -1,12 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_conversation_memo/topic_list_page.dart';
 import 'widget_test_helper.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('ネタ一覧が表示されること', (WidgetTester tester) async {
     await tester.pumpWidget(wrapWithMaterial(TopicListPage()));
 
     expect(find.text('WIP'), findsOneWidget);
+  });
+
+  testWidgets('新規作成ボタンを押したとき、ネタ新規追加ページが開くこと', (WidgetTester tester) async {
+    await tester.pumpWidget(wrapWithMaterial(TopicListPage()));
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    expect(find.text('ネタ新規追加', skipOffstage: false), findsOneWidget);
   });
 }


### PR DESCRIPTION
## やったこと
- ネタ一覧ページの`+`ボタンを押したときに、新規作成ページを表示

## 参照
- https://github.com/ken1flan/flutter_conversation_memo/issues/5