### PR TITLE
話題のページにテキストフィールドを設置

### DIFF
--- a/lib/topic_page.dart
+++ b/lib/topic_page.dart
@@ -5,18 +5,27 @@ class TopicPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('会話ネタ帳'),
+        title: Text('話題の新規作成 | 会話ネタ帳'),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              'ネタ新規追加',
+      body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(children: [
+            TextField(
+              decoration: const InputDecoration(
+                  labelText: 'いいたいこと', hintText: 'この話題で言いたいことを短くまとめましょう。'),
             ),
-          ],
-        ),
-      ),
+            TextField(
+              decoration: const InputDecoration(
+                  labelText: 'メモ',
+                  hintText:
+                      '話題を話すときにチラ見したいことを書きましょう。\n長くしすぎるとスクロールが入って見づらくなるかもしれません。'),
+              maxLines: 10,
+            ),
+            TextField(
+              decoration: const InputDecoration(
+                  labelText: 'タグ', hintText: 'スペースで区切って入力してください。'),
+            ),
+          ])),
     );
   }
 }

--- a/test/topic_list_page_test.dart
+++ b/test/topic_list_page_test.dart
@@ -17,6 +17,6 @@ void main() {
     await tester.tap(find.byIcon(Icons.add));
     await tester.pump();
 
-    expect(find.text('ネタ新規追加', skipOffstage: false), findsOneWidget);
+    expect(find.text('話題の新規作成 | 会話ネタ帳', skipOffstage: false), findsOneWidget);
   });
 }


### PR DESCRIPTION
話題のページでデータを登録/編集できるようにテキストフィールドを設置しました。
ただし、まだ保存していません。

<img src='https://user-images.githubusercontent.com/2942348/117102976-6418d680-adb4-11eb-9116-3b7afcc70316.png' width='50%'>

## 参照
- https://github.com/ken1flan/flutter_conversation_memo/issues/4