### PR TITLE
非同期処理の見直し

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,7 @@ void main() async {
   await Hive.initFlutter();
   Hive.registerAdapter(TopicAdapter());
   await Hive.openBox<Topic>(topicBoxName);
-  Person.initialize();
+  await Person.initialize();
   timeago.setLocaleMessages('ja', timeago.JaMessages());
   runApp(MyApp());
 }

--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -6,7 +6,9 @@ const int PersonTypeId = 1;
 
 @HiveType(typeId: PersonTypeId)
 class Person {
+  static Box<Person> _box;
   int index;
+
   @HiveField(0)
   String name;
   @HiveField(1)
@@ -23,20 +25,13 @@ class Person {
 
   static const boxName = 'personBox';
 
-  static void initialize() async {
-    if (!Hive.isAdapterRegistered(PersonTypeId)) {
-      Hive.registerAdapter(PersonAdapter());
-    }
-
-    if (!Hive.isBoxOpen(boxName)) {
-      await Hive.openBox<Person>(boxName);
-    }
+  static Future<void> initialize() async {
+    Hive.registerAdapter(PersonAdapter());
+    _box = await Hive.openBox<Person>(boxName);
   }
 
   static Box<Person> box() {
-    initialize();
-
-    return Hive.box<Person>(boxName);
+    return _box;
   }
 
   static Person getAt(int index) {

--- a/test/models/person_test.dart
+++ b/test/models/person_test.dart
@@ -5,10 +5,14 @@ import 'package:flutter_conversation_memo/models/person.dart';
 
 void main() async {
   await initializeHive();
-  Person.initialize();
+  await Person.initialize();
 
-  tearDownAll(() {
-    tearDownHive();
+  tearDown(() async {
+    await Person.box().clear();
+  });
+
+  tearDownAll(() async {
+    await finalizeHive();
   });
 
   group('.getAt(index)', () {

--- a/test/supports/hive.dart
+++ b/test/supports/hive.dart
@@ -7,6 +7,6 @@ Future<void> initializeHive() async {
   Hive.init(path);
 }
 
-Future<void> tearDownHive() async {
+Future<void> finalizeHive() async {
   await Hive.deleteFromDisk();
 }


### PR DESCRIPTION
Personでなにかをしようとしてbox()を使ったら自動的にinitializeさせたかったけど、同期処理と非同期処理を同居できなそうだったので、分けることにしました。

非同期処理のopenBoxをawaitするようになったはずなので、テストの不安定さも消えたはずです。