### PR TITLE
興味のありそうな人/話題のリストを話題/人の編集ページに追加

### DIFF
--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -7,6 +7,8 @@ const int PersonTypeId = 1;
 
 @HiveType(typeId: PersonTypeId)
 class Person {
+  String TAG_SEPARATOR = ' ';
+
   static Box<Person> _box;
   int index;
 
@@ -56,5 +58,19 @@ class Person {
     } else {
       box.putAt(index, this);
     }
+  }
+
+  List<String> tags() {
+    if (tags_string == null) {
+      return [];
+    }
+    List<String> tags = [];
+    tags_string.split(TAG_SEPARATOR).forEach((element) {
+      if (element != null && element != '') {
+        tags.add(element);
+      }
+    });
+
+    return tags;
   }
 }

--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -7,7 +7,8 @@ const int PersonTypeId = 1;
 
 @HiveType(typeId: PersonTypeId)
 class Person {
-  String TAG_SEPARATOR = ' ';
+  static const boxName = 'personBox';
+  static const String TAG_SEPARATOR = ' ';
 
   static Box<Person> _box;
   int index;
@@ -25,8 +26,6 @@ class Person {
 
   Person(
       this.name, this.memo, this.tags_string, this.created_at, this.updated_at);
-
-  static const boxName = 'personBox';
 
   static Future<void> initialize({memory_box = false}) async {
     Hive.registerAdapter(PersonAdapter());

--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -48,6 +48,21 @@ class Person {
     return box().deleteAt(index);
   }
 
+  static Map<dynamic, Person> searchByTags(List<String> tags) {
+    var persons = box().toMap();
+
+    persons.removeWhere((index, person) {
+      return !(person.tags().any((person_tag) {
+        // Mapでwhere()が使えないので否定条件でremoveWhere()を使っています。
+        return tags.any((tag) {
+          return tag == person_tag;
+        });
+      }));
+    });
+
+    return persons;
+  }
+
   void save() {
     var box = Person.box();
     updated_at = DateTime.now().toUtc();

--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -78,7 +78,7 @@ class Person {
     if (tags_string == null) {
       return [];
     }
-    List<String> tags = [];
+    var tags = <String>[];
     tags_string.split(TAG_SEPARATOR).forEach((element) {
       if (element != null && element != '') {
         tags.add(element);

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -7,6 +7,8 @@ const int TopicTypeId = 0;
 @HiveType(typeId: TopicTypeId)
 class Topic {
   static const String boxName = 'topicBox';
+  static const String TAG_SEPARATOR = ' ';
+
   static Box<Topic> _box;
   int index;
 
@@ -32,5 +34,56 @@ class Topic {
 
   static Box<Topic> box() {
     return _box;
+  }
+
+  static Topic getAt(int index) {
+    var topic = box().getAt(index);
+    topic.index = index;
+    return topic;
+  }
+
+  static Future<void> deleteAt(int index) async {
+    return box().deleteAt(index);
+  }
+
+  static Map<dynamic, Topic> searchByTags(List<String> tags) {
+    var topics = box().toMap();
+
+    topics.removeWhere((index, topic) {
+      return !(topic.tags().any((topic_tag) {
+        // Mapでwhere()が使えないので否定条件でremoveWhere()を使っています。
+        return tags.any((tag) {
+          return tag == topic_tag;
+        });
+      }));
+    });
+
+    return topics;
+  }
+
+  void save() {
+    var box = Topic.box();
+    updated_at = DateTime.now().toUtc();
+
+    if (index == null) {
+      created_at = updated_at;
+      box.add(this);
+    } else {
+      box.putAt(index, this);
+    }
+  }
+
+  List<String> tags() {
+    if (tags_string == null) {
+      return [];
+    }
+    List<String> tags = [];
+    tags_string.split(TAG_SEPARATOR).forEach((element) {
+      if (element != null && element != '') {
+        tags.add(element);
+      }
+    });
+
+    return tags;
   }
 }

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -77,7 +77,7 @@ class Topic {
     if (tags_string == null) {
       return [];
     }
-    List<String> tags = [];
+    var tags = <String>[];
     tags_string.split(TAG_SEPARATOR).forEach((element) {
       if (element != null && element != '') {
         tags.add(element);

--- a/lib/widgets/person_page.dart
+++ b/lib/widgets/person_page.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter_conversation_memo/models/person.dart';
+import 'package:flutter_conversation_memo/models/topic.dart';
+import 'package:flutter_conversation_memo/widgets/topic_card.dart';
 
 class PersonPage extends StatefulWidget {
   final formKey = GlobalKey<FormState>();
@@ -47,6 +51,7 @@ class _PersonPageState extends State<PersonPage> {
       text: tags_string,
       selection: TextSelection.collapsed(offset: tags_string.length),
     ));
+    final interestedTopics = Topic.box().toMap();
 
     return Scaffold(
         appBar: AppBar(
@@ -92,12 +97,24 @@ class _PersonPageState extends State<PersonPage> {
                   },
                 ),
                 Padding(
-                  padding: const EdgeInsets.only(top: 32),
+                  padding: const EdgeInsets.only(top: 32, bottom: 32),
                   child: ElevatedButton(
                     key: Key('saveButton'),
                     onPressed: onFormSubmit,
                     child: Text('保存'),
                   ),
+                ),
+                Text('興味のありそうな話題'),
+                ValueListenableBuilder(
+                  valueListenable: Topic.box().listenable(),
+                  builder: (context, Box<Topic> box, _) {
+                    //if (box.values.isEmpty) {
+                    return Center(
+                      child: Text('まだありません。'),
+                    );
+                    //}
+                    //
+                  },
                 ),
               ],
             )));

--- a/lib/widgets/person_page.dart
+++ b/lib/widgets/person_page.dart
@@ -38,7 +38,7 @@ class _PersonPageState extends State<PersonPage> {
 
   @override
   Widget build(BuildContext context) {
-    final titleString = '人の新規作成 | 会話ネタ帳';
+    final titleString = index == null ? '人の新規作成 | 会話ネタ帳' : '人の編集 | 会話ネタ帳';
     final nameEditingController =
         TextEditingController.fromValue(TextEditingValue(
       text: name,

--- a/lib/widgets/person_page.dart
+++ b/lib/widgets/person_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_conversation_memo/models/person.dart';
 import 'package:flutter_conversation_memo/models/topic.dart';
 import 'package:flutter_conversation_memo/widgets/topic_card.dart';
@@ -17,19 +16,23 @@ class PersonPage extends StatefulWidget {
 
 class _PersonPageState extends State<PersonPage> {
   int index;
+  Person person;
   String name = '';
   String memo = '';
   String tags_string = '';
   DateTime created_at;
   DateTime updated_at;
+  Map<dynamic, Topic> interestedTopics;
 
   _PersonPageState(index) {
     this.index = index;
     if (index != null) {
-      var person = Person.getAt(index);
+      person = Person.getAt(index);
       name = person?.name;
       memo = person?.memo;
       tags_string = person?.tags_string;
+
+      interestedTopics = Topic.searchByTags(person.tags());
     }
   }
 
@@ -51,7 +54,7 @@ class _PersonPageState extends State<PersonPage> {
       text: tags_string,
       selection: TextSelection.collapsed(offset: tags_string.length),
     ));
-    final interestedTopics = Topic.box().toMap();
+    var localizations = AppLocalizations.of(context);
 
     return Scaffold(
         appBar: AppBar(
@@ -105,17 +108,19 @@ class _PersonPageState extends State<PersonPage> {
                   ),
                 ),
                 Text('興味のありそうな話題'),
-                ValueListenableBuilder(
-                  valueListenable: Topic.box().listenable(),
-                  builder: (context, Box<Topic> box, _) {
-                    //if (box.values.isEmpty) {
-                    return Center(
-                      child: Text('まだありません。'),
-                    );
-                    //}
-                    //
-                  },
-                ),
+                Builder(builder: (BuildContext context) {
+                  if (interestedTopics == null) {
+                    return Center(child: Text(localizations.notFound));
+                  } else {
+                    return ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: interestedTopics.length,
+                        itemBuilder: (context, index) {
+                          return TopicCard(
+                              context, index, interestedTopics[index]);
+                        });
+                  }
+                }),
               ],
             )));
   }

--- a/lib/widgets/person_page.dart
+++ b/lib/widgets/person_page.dart
@@ -116,8 +116,8 @@ class _PersonPageState extends State<PersonPage> {
                         shrinkWrap: true,
                         itemCount: interestedTopics.length,
                         itemBuilder: (context, index) {
-                          return TopicCard(
-                              context, index, interestedTopics[index]);
+                          var key = interestedTopics.keys.elementAt(index);
+                          return TopicCard(context, key, interestedTopics[key]);
                         });
                   }
                 }),

--- a/lib/widgets/topic_page.dart
+++ b/lib/widgets/topic_page.dart
@@ -119,8 +119,8 @@ class _TopicPageState extends State<TopicPage> {
                     shrinkWrap: true,
                     itemCount: interestedPersons.length,
                     itemBuilder: (context, index) {
-                      return PersonCard(
-                          context, index, interestedPersons[index]);
+                      var key = interestedPersons.keys.elementAt(index);
+                      return PersonCard(context, key, interestedPersons[key]);
                     });
               }
             }),

--- a/lib/widgets/topic_page.dart
+++ b/lib/widgets/topic_page.dart
@@ -66,7 +66,6 @@ class _TopicPageState extends State<TopicPage> {
       body: Padding(
           padding: const EdgeInsets.all(16),
           child: ListView(children: [
-            Text('summaryTextField$indexString'),
             TextField(
               key: ValueKey('summaryTextField$indexString'),
               controller: summaryEditingController,

--- a/test/models/person_test.dart
+++ b/test/models/person_test.dart
@@ -4,11 +4,12 @@ import '../supports/hive.dart';
 import 'package:flutter_conversation_memo/models/person.dart';
 
 void main() async {
-  initializeHive();
-  await Person.initialize(memory_box: true);
+  setUpAll(() {
+    initializeHive();
+  });
 
   tearDown(() async {
-    await Person.box().clear();
+    await tearDownHive();
   });
 
   group('.getAt(index)', () {

--- a/test/models/person_test.dart
+++ b/test/models/person_test.dart
@@ -75,4 +75,50 @@ void main() async {
       });
     });
   });
+
+  group('#tags', () {
+    group('tags_string = nullのとき', () {
+      test('空のリストを返すこと', () {
+        var person = Person('yamada', 'memo\nmemo', null, null, null);
+
+        expect(person.tags(), isEmpty);
+      });
+    });
+
+    group('tags_string = ""のとき', () {
+      test('空のリストを返すこと', () {
+        var person = Person('yamada', 'memo\nmemo', '', null, null);
+
+        print(person.tags());
+        expect(person.tags(), isEmpty);
+      });
+    });
+
+    group('tags_string = "tag1"のとき', () {
+      test('["tag1"]を返すこと', () {
+        var person = Person('yamada', 'memo\nmemo', 'tag1', null, null);
+
+        print(person.tags());
+        expect(person.tags(), equals(['tag1']));
+      });
+    });
+
+    group('tags_string = "tag1 tag2"のとき', () {
+      test('["tag1", "tag2]を返すこと', () {
+        var person = Person('yamada', 'memo\nmemo', 'tag1 tag2', null, null);
+
+        print(person.tags());
+        expect(person.tags(), equals(['tag1', 'tag2']));
+      });
+    });
+
+    group('tags_string = " tag1  tag2 "のとき', () {
+      test('["tag1", "tag2]を返すこと', () {
+        var person = Person('yamada', 'memo\nmemo', ' tag1  tag2 ', null, null);
+
+        print(person.tags());
+        expect(person.tags(), equals(['tag1', 'tag2']));
+      });
+    });
+  });
 }

--- a/test/models/person_test.dart
+++ b/test/models/person_test.dart
@@ -76,6 +76,67 @@ void main() async {
     });
   });
 
+  group('.searchByTags', () {
+    group('1件も登録されていないとき', () {
+      test('空のリストを返すこと', () {
+        var tags = ['tag'];
+        expect(Person.searchByTags(tags), isEmpty);
+      });
+    });
+
+    group('3件登録されているとき', () {
+      setUp(() {
+        Person('yamada', 'memo\nmemo', 'tag1 tag2', null, null).save();
+        Person('sato', 'memo\nmemo', 'tag3 tag4', null, null).save();
+        Person('tanaka', 'memo\nmemo', 'tag2 tag9', null, null).save();
+      });
+
+      test('タグに空の配列を指定したとき、空のリストを返すこと', () {
+        var tags = <String>[];
+        // expect(Person.searchByTags(tags), equals(Person.box().toMap()));
+        expect(Person.searchByTags(tags), isEmpty);
+      });
+
+      test('存在しないタグを指定したとき、空のリストを返すこと', () {
+        var tags = <String>['tagx', 'tagy'];
+        expect(Person.searchByTags(tags), isEmpty);
+      });
+
+      test('1件ヒットするタグを指定したとき、1件のリストを返すこと', () {
+        var tags = <String>['tag3', 'tagx'];
+        var names = Person.searchByTags(tags)
+            .values
+            .map((person) => person.name)
+            .toList();
+        expect(names, contains('sato'));
+        expect(names, isNot(contains('yamada')));
+        expect(names, isNot(contains('tanaka')));
+      });
+
+      test('2件ヒットするタグを指定したとき、2件のリストを返すこと', () {
+        var tags = <String>['tagx', 'tag2'];
+        var names = Person.searchByTags(tags)
+            .values
+            .map((person) => person.name)
+            .toList();
+        expect(names, contains('yamada'));
+        expect(names, contains('tanaka'));
+        expect(names, isNot(contains('sato')));
+      });
+
+      test('1件ヒットするタグを2つ指定したとき、2件のリストを返すこと', () {
+        var tags = <String>['tag1', 'tagx', 'tag3'];
+        var names = Person.searchByTags(tags)
+            .values
+            .map((person) => person.name)
+            .toList();
+        expect(names, contains('yamada'));
+        expect(names, contains('sato'));
+        expect(names, isNot(contains('tanaka')));
+      });
+    });
+  });
+
   group('#tags', () {
     group('tags_string = nullのとき', () {
       test('空のリストを返すこと', () {

--- a/test/models/topic_test.dart
+++ b/test/models/topic_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../supports/hive.dart';
+import 'package:flutter_conversation_memo/models/topic.dart';
+
+void main() async {
+  initializeHive();
+  await Topic.initialize(memory_box: true);
+
+  tearDown(() async {
+    await Topic.box().clear();
+  });
+
+  group('.getAt(index)', () {
+    group('1件もないとき', () {
+      test('存在しないindexを指定したとき、RangeErrorになること', () {
+        expect(() => Topic.getAt(999), throwsA(TypeMatcher<RangeError>()));
+      });
+    });
+
+    group('1件あったとき', () {
+      setUpAll(() {
+        Topic('omoroikoto', 'memo\nmemo', 'tag1 tag2', null, null).save();
+      });
+
+      test('存在するindexを指定したとき、Topicが取得できること', () {
+        var topic = Topic.getAt(0);
+        expect(topic.summary, equals('omoroikoto'));
+        expect(topic.memo, equals('memo\nmemo'));
+        expect(topic.tags_string, equals('tag1 tag2'));
+      });
+
+      test('存在しないindexを指定したとき、RangeErrorになること', () {
+        expect(() => Topic.getAt(999), throwsA(TypeMatcher<RangeError>()));
+      });
+    });
+  });
+
+  group('#save()', () {
+    group('新規作成', () {
+      test('保存した内容が取得できること', () {
+        Topic('omoroikoto', 'memo\nmemo', 'tag1 tag2', null, null).save();
+
+        var topic = Topic.getAt(0);
+        expect(topic.summary, equals('omoroikoto'));
+        expect(topic.memo, equals('memo\nmemo'));
+        expect(topic.tags_string, equals('tag1 tag2'));
+        expect(topic.created_at, isInstanceOf<DateTime>());
+        expect(topic.updated_at, isInstanceOf<DateTime>());
+        expect(topic.updated_at, equals(topic.created_at));
+      });
+    });
+
+    group('更新', () {
+      setUpAll(() {
+        Topic('omoroikoto', 'memo\nmemo', 'tag1 tag2', null, null).save();
+      });
+
+      test('既存のレコードの内容を変更後、再取得したときに更新後のデータを取得できること', () {
+        var topic = Topic.getAt(0);
+
+        topic.summary = 'tanoshikattakoto';
+        topic.memo = 'memo\nmemo\nmemo';
+        topic.tags_string = 'tag9 tag8';
+        topic.save();
+
+        var updatedTopic = Topic.getAt(0);
+        expect(updatedTopic.summary, equals('tanoshikattakoto'));
+        expect(updatedTopic.memo, equals('memo\nmemo\nmemo'));
+        expect(updatedTopic.tags_string, equals('tag9 tag8'));
+        expect(topic.created_at, isInstanceOf<DateTime>());
+        expect(topic.updated_at, isInstanceOf<DateTime>());
+        expect(topic.updated_at.microsecondsSinceEpoch,
+            greaterThan(topic.created_at.microsecondsSinceEpoch));
+      });
+    });
+  });
+
+  group('.searchByTags', () {
+    group('1件も登録されていないとき', () {
+      test('空のリストを返すこと', () {
+        var tags = ['tag'];
+        expect(Topic.searchByTags(tags), isEmpty);
+      });
+    });
+
+    group('3件登録されているとき', () {
+      setUp(() {
+        Topic('omoroikoto', 'memo\nmemo', 'tag1 tag2', null, null).save();
+        Topic('tanoshiikoto', 'memo\nmemo', 'tag3 tag4', null, null).save();
+        Topic('iketerukoto', 'memo\nmemo', 'tag2 tag9', null, null).save();
+      });
+
+      test('タグに空の配列を指定したとき、空のリストを返すこと', () {
+        var tags = <String>[];
+        // expect(Topic.searchByTags(tags), equals(Topic.box().toMap()));
+        expect(Topic.searchByTags(tags), isEmpty);
+      });
+
+      test('存在しないタグを指定したとき、空のリストを返すこと', () {
+        var tags = <String>['tagx', 'tagy'];
+        expect(Topic.searchByTags(tags), isEmpty);
+      });
+
+      test('1件ヒットするタグを指定したとき、1件のリストを返すこと', () {
+        var tags = <String>['tag3', 'tagx'];
+        var summaries = Topic.searchByTags(tags)
+            .values
+            .map((topic) => topic.summary)
+            .toList();
+        expect(summaries, contains('tanoshiikoto'));
+        expect(summaries, isNot(contains('omoroikoto')));
+        expect(summaries, isNot(contains('iketerukoto')));
+      });
+
+      test('2件ヒットするタグを指定したとき、2件のリストを返すこと', () {
+        var tags = <String>['tagx', 'tag2'];
+        var summaries = Topic.searchByTags(tags)
+            .values
+            .map((topic) => topic.summary)
+            .toList();
+        expect(summaries, contains('omoroikoto'));
+        expect(summaries, contains('iketerukoto'));
+        expect(summaries, isNot(contains('tanoshiikoto')));
+      });
+
+      test('1件ヒットするタグを2つ指定したとき、2件のリストを返すこと', () {
+        var tags = <String>['tag1', 'tagx', 'tag3'];
+        var summaries = Topic.searchByTags(tags)
+            .values
+            .map((topic) => topic.summary)
+            .toList();
+        expect(summaries, contains('omoroikoto'));
+        expect(summaries, contains('tanoshiikoto'));
+        expect(summaries, isNot(contains('iketerukoto')));
+      });
+    });
+  });
+
+  group('#tags', () {
+    group('tags_string = nullのとき', () {
+      test('空のリストを返すこと', () {
+        var topic = Topic('omoroikoto', 'memo\nmemo', null, null, null);
+
+        expect(topic.tags(), isEmpty);
+      });
+    });
+
+    group('tags_string = ""のとき', () {
+      test('空のリストを返すこと', () {
+        var topic = Topic('omoroikoto', 'memo\nmemo', '', null, null);
+
+        print(topic.tags());
+        expect(topic.tags(), isEmpty);
+      });
+    });
+
+    group('tags_string = "tag1"のとき', () {
+      test('["tag1"]を返すこと', () {
+        var topic = Topic('omoroikoto', 'memo\nmemo', 'tag1', null, null);
+
+        print(topic.tags());
+        expect(topic.tags(), equals(['tag1']));
+      });
+    });
+
+    group('tags_string = "tag1 tag2"のとき', () {
+      test('["tag1", "tag2]を返すこと', () {
+        var topic = Topic('omoroikoto', 'memo\nmemo', 'tag1 tag2', null, null);
+
+        print(topic.tags());
+        expect(topic.tags(), equals(['tag1', 'tag2']));
+      });
+    });
+
+    group('tags_string = " tag1  tag2 "のとき', () {
+      test('["tag1", "tag2]を返すこと', () {
+        var topic =
+            Topic('omoroikoto', 'memo\nmemo', ' tag1  tag2 ', null, null);
+
+        print(topic.tags());
+        expect(topic.tags(), equals(['tag1', 'tag2']));
+      });
+    });
+  });
+}

--- a/test/models/topic_test.dart
+++ b/test/models/topic_test.dart
@@ -4,11 +4,12 @@ import '../supports/hive.dart';
 import 'package:flutter_conversation_memo/models/topic.dart';
 
 void main() async {
-  initializeHive();
-  await Topic.initialize(memory_box: true);
+  setUpAll(() {
+    initializeHive();
+  });
 
   tearDown(() async {
-    await Topic.box().clear();
+    await tearDownHive();
   });
 
   group('.getAt(index)', () {

--- a/test/supports/hive.dart
+++ b/test/supports/hive.dart
@@ -1,10 +1,19 @@
 import 'dart:io';
 import 'package:hive/hive.dart';
+import 'package:flutter_conversation_memo/models/person.dart';
+import 'package:flutter_conversation_memo/models/topic.dart';
 
-void initializeHive() {
+Future<void> initializeHive() async {
   final path = Directory.current.path;
 
   Hive.init(path);
+  await Topic.initialize(memory_box: true);
+  await Person.initialize(memory_box: true);
+}
+
+Future<void> tearDownHive() async {
+  await Topic.box().clear();
+  await Person.box().clear();
 }
 
 void finalizeHive() async {

--- a/test/widgets/person_list_page_test.dart
+++ b/test/widgets/person_list_page_test.dart
@@ -1,24 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
 import 'package:flutter_conversation_memo/widgets/person_list_page.dart';
 import 'package:flutter_conversation_memo/models/person.dart';
+import '../supports/hive.dart';
 import '../widget_test_helper.dart';
 
 void main() async {
   setUpAll(() async {
-    final path = Directory.current.path;
-    Hive.init(path);
-    await Person.initialize(memory_box: true);
+    await initializeHive();
   });
 
-  tearDown(() {
-    var box = Person.box();
-    if (box.isNotEmpty) {
-      Person.box().clear();
-    }
+  tearDown(() async {
+    await tearDownHive();
   });
 
   group('Personが0個のとき', () {

--- a/test/widgets/person_page_test.dart
+++ b/test/widgets/person_page_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_conversation_memo/widgets/person_page.dart';
+import 'package:flutter_conversation_memo/models/person.dart';
+import '../supports/hive.dart';
+import '../widget_test_helper.dart';
+
+void main() async {
+  setUpAll(() async {
+    await initializeHive();
+  });
+
+  tearDown(() async {
+    await tearDownHive();
+  });
+
+  group('Personが存在しないとき', () {
+    testWidgets('Personが指定されていないとき、新規作成ページが表示されていること',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(wrapWithMaterial(PersonPage()));
+
+      expect(find.text('人の新規作成 | 会話ネタ帳', skipOffstage: false), findsOneWidget);
+    });
+  });
+
+  group('Personが存在するとき', () {
+    setUp(() {
+      Person('Yamada', 'Memo', '', null, null).save();
+    });
+
+    testWidgets('Personが指定されているとき、編集ページが表示されていること',
+        (WidgetTester tester) async {
+      var index = 0;
+
+      await tester.pumpWidget(wrapWithMaterial(PersonPage(index: index)));
+
+      expect(find.text('人の編集 | 会話ネタ帳', skipOffstage: false), findsOneWidget);
+    });
+  });
+}

--- a/test/widgets/topic_list_page_test.dart
+++ b/test/widgets/topic_list_page_test.dart
@@ -1,24 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
 import 'package:flutter_conversation_memo/widgets/topic_list_page.dart';
 import 'package:flutter_conversation_memo/models/topic.dart';
+import '../supports/hive.dart';
 import '../widget_test_helper.dart';
 
 void main() async {
   setUpAll(() async {
-    final path = Directory.current.path;
-    Hive.init(path);
-    await Topic.initialize(memory_box: true);
+    await initializeHive();
   });
 
   tearDown(() async {
-    var box = Topic.box();
-    if (box.isNotEmpty) {
-      await Topic.box().clear();
-    }
+    await tearDownHive();
   });
 
   group('Topicが0個のとき', () {

--- a/test/widgets/topic_page_test.dart
+++ b/test/widgets/topic_page_test.dart
@@ -1,35 +1,36 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:hive/hive.dart';
 import 'package:flutter_conversation_memo/widgets/topic_page.dart';
 import 'package:flutter_conversation_memo/models/topic.dart';
+import '../supports/hive.dart';
 import '../widget_test_helper.dart';
 
 void main() async {
-  await initializeTest();
-
-  setUp(() async {
-    await initializeExample();
+  setUpAll(() async {
+    await initializeHive();
   });
 
   tearDown(() async {
-    await finalizeExample();
+    await tearDownHive();
   });
 
-  testWidgets('Topicが指定されていないとき、新規作成ページが表示されていること',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(wrapWithMaterial(TopicPage()));
+  group('Topicが存在しないとき', () {
+    testWidgets('Topicが指定されていないとき、新規作成ページが表示されていること',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(wrapWithMaterial(TopicPage()));
 
-    expect(find.text('話題の新規作成 | 会話ネタ帳', skipOffstage: false), findsOneWidget);
+      expect(find.text('話題の新規作成 | 会話ネタ帳', skipOffstage: false), findsOneWidget);
+    });
   });
 
-  testWidgets('Topicが指定されているとき、編集ページが表示されていること', (WidgetTester tester) async {
-    var box = Hive.box<Topic>(topicBoxName);
-    await box.add(Topic('Summary', 'Memo', '', DateTime.now(), DateTime.now()));
-    var index = 0;
+  group('Topicが存在するとき', () {
+    testWidgets('Topicが指定されているとき、編集ページが表示されていること', (WidgetTester tester) async {
+      Topic('Summary', 'Memo', '', null, null).save();
+      var index = 0;
 
-    await tester.pumpWidget(wrapWithMaterial(TopicPage(index: index)));
+      await tester.pumpWidget(wrapWithMaterial(TopicPage(index: index)));
 
-    expect(find.text('話題の編集 | 会話ネタ帳', skipOffstage: false), findsOneWidget);
+      expect(find.text('話題の編集 | 会話ネタ帳', skipOffstage: false), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
話題のページに、話題に設定されているタグと同じものがタグに設定されている人を表示したり、
人のページに、人に設定されているタグと同じものがタグに設定されている話題を表示したりするようにします。

<img width='30%' src='https://user-images.githubusercontent.com/2942348/127738822-bf14b872-1c79-4293-9293-c1d8d8c72548.png'>
<img width='30%' src='https://user-images.githubusercontent.com/2942348/127738845-7b4094c2-9c66-41fc-b667-00e48c2a3aab.png'>
