### PR TITLE
Extend HiveObject

### DIFF
--- a/lib/models/person.dart
+++ b/lib/models/person.dart
@@ -39,10 +39,6 @@ class Person extends HiveObject {
     return person;
   }
 
-  static Future<void> deleteAt(int index) async {
-    return internalBox.deleteAt(index);
-  }
-
   static Map<dynamic, Person> searchByTags(List<String> tags) {
     var persons = internalBox.toMap();
 

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -38,10 +38,6 @@ class Topic extends HiveObject {
     return topic;
   }
 
-  static Future<void> deleteAt(int index) async {
-    return internalBox.deleteAt(index);
-  }
-
   static Map<dynamic, Topic> searchByTags(List<String> tags) {
     var topics = internalBox.toMap();
 

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -5,11 +5,11 @@ part 'topic.g.dart';
 const int TopicTypeId = 0;
 
 @HiveType(typeId: TopicTypeId)
-class Topic {
+class Topic extends HiveObject {
   static const String boxName = 'topicBox';
   static const String TAG_SEPARATOR = ' ';
 
-  static Box<Topic> _box;
+  static Box<Topic> internalBox;
   int index;
 
   @HiveField(0)
@@ -29,25 +29,21 @@ class Topic {
   static Future<void> initialize({memory_box = false}) async {
     Hive.registerAdapter(TopicAdapter());
     var bytes = memory_box ? Uint8List(0) : null;
-    _box = await Hive.openBox<Topic>(boxName, bytes: bytes);
-  }
-
-  static Box<Topic> box() {
-    return _box;
+    internalBox = await Hive.openBox<Topic>(boxName, bytes: bytes);
   }
 
   static Topic getAt(int index) {
-    var topic = box().getAt(index);
+    var topic = internalBox.getAt(index);
     topic.index = index;
     return topic;
   }
 
   static Future<void> deleteAt(int index) async {
-    return box().deleteAt(index);
+    return internalBox.deleteAt(index);
   }
 
   static Map<dynamic, Topic> searchByTags(List<String> tags) {
-    var topics = box().toMap();
+    var topics = internalBox.toMap();
 
     topics.removeWhere((index, topic) {
       return !(topic.tags().any((topic_tag) {
@@ -61,15 +57,16 @@ class Topic {
     return topics;
   }
 
-  void save() {
-    var box = Topic.box();
+  @override
+  Future<void> save() {
+    var box = Topic.internalBox;
     updated_at = DateTime.now().toUtc();
 
     if (index == null) {
       created_at = updated_at;
-      box.add(this);
+      return box.add(this);
     } else {
-      box.putAt(index, this);
+      return super.save();
     }
   }
 

--- a/lib/widgets/person_card.dart
+++ b/lib/widgets/person_card.dart
@@ -28,7 +28,7 @@ class PersonCard extends Card {
                         ),
                         TextButton(
                           onPressed: () async {
-                            await Person.deleteAt(index);
+                            await person.delete();
                             Navigator.of(context).pop();
                           },
                           child: Text(localizations.personDeleteConfirmYes),

--- a/lib/widgets/person_list_page.dart
+++ b/lib/widgets/person_list_page.dart
@@ -19,7 +19,7 @@ class PersonListPage extends StatelessWidget {
       ),
       drawer: createDrawer(context),
       body: ValueListenableBuilder(
-        valueListenable: Person.box().listenable(),
+        valueListenable: Person.internalBox.listenable(),
         builder: (context, Box<Person> box, _) {
           if (box.values.isEmpty) {
             return Center(

--- a/lib/widgets/topic_card.dart
+++ b/lib/widgets/topic_card.dart
@@ -29,7 +29,7 @@ class TopicCard extends Card {
                         ),
                         TextButton(
                           onPressed: () async {
-                            await Topic.internalBox.deleteAt(index);
+                            await topic.delete();
                             Navigator.of(context).pop();
                           },
                           child: Text(localizations.topicDeleteConfirmYes),

--- a/lib/widgets/topic_card.dart
+++ b/lib/widgets/topic_card.dart
@@ -29,7 +29,7 @@ class TopicCard extends Card {
                         ),
                         TextButton(
                           onPressed: () async {
-                            await Topic.box().deleteAt(index);
+                            await Topic.internalBox.deleteAt(index);
                             Navigator.of(context).pop();
                           },
                           child: Text(localizations.topicDeleteConfirmYes),

--- a/lib/widgets/topic_list_page.dart
+++ b/lib/widgets/topic_list_page.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_conversation_memo/main.dart';
@@ -26,6 +28,14 @@ class TopicListPage extends StatelessWidget {
                   child: Text(localizations.notFound),
                 );
               }
+              // 更新日逆順にしたtopicのリストを作る
+              // Topicのリストを得る
+              var topics = box.toMap();
+              var sortedTopics = SplayTreeMap.from(
+                  topics,
+                  (a, b) =>
+                      topics[a].updated_at.compareTo(topics[b].updated_at));
+              // 並べ替える
               return ListView.builder(
                 itemCount: box.values.length,
                 itemBuilder: (context, index) {

--- a/lib/widgets/topic_list_page.dart
+++ b/lib/widgets/topic_list_page.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_conversation_memo/main.dart';
@@ -28,14 +26,6 @@ class TopicListPage extends StatelessWidget {
                   child: Text(localizations.notFound),
                 );
               }
-              // 更新日逆順にしたtopicのリストを作る
-              // Topicのリストを得る
-              var topics = box.toMap();
-              var sortedTopics = SplayTreeMap.from(
-                  topics,
-                  (a, b) =>
-                      topics[a].updated_at.compareTo(topics[b].updated_at));
-              // 並べ替える
               return ListView.builder(
                 itemCount: box.values.length,
                 itemBuilder: (context, index) {

--- a/test/models/topic_test.dart
+++ b/test/models/topic_test.dart
@@ -20,8 +20,8 @@ void main() async {
     });
 
     group('1件あったとき', () {
-      setUpAll(() {
-        Topic('omoroikoto', 'memo\nmemo', 'tag1 tag2', null, null).save();
+      setUpAll(() async {
+        await Topic('omoroikoto', 'memo\nmemo', 'tag1 tag2', null, null).save();
       });
 
       test('存在するindexを指定したとき、Topicが取得できること', () {
@@ -94,7 +94,6 @@ void main() async {
 
       test('タグに空の配列を指定したとき、空のリストを返すこと', () {
         var tags = <String>[];
-        // expect(Topic.searchByTags(tags), equals(Topic.box().toMap()));
         expect(Topic.searchByTags(tags), isEmpty);
       });
 

--- a/test/supports/hive.dart
+++ b/test/supports/hive.dart
@@ -12,8 +12,8 @@ Future<void> initializeHive() async {
 }
 
 Future<void> tearDownHive() async {
-  await Topic.box().clear();
-  await Person.box().clear();
+  await Topic.internalBox.clear();
+  await Person.internalBox.clear();
 }
 
 void finalizeHive() async {

--- a/test/widgets/topic_list_page_test.dart
+++ b/test/widgets/topic_list_page_test.dart
@@ -34,7 +34,7 @@ void main() async {
 
   group('Topicが1個のとき', () {
     setUp(() async {
-      var box = Topic.box();
+      var box = Topic.internalBox;
       await box
           .add(Topic('Summary', 'Memo', '', DateTime.now(), DateTime.now()));
     });

--- a/test/widgets/topic_page_test.dart
+++ b/test/widgets/topic_page_test.dart
@@ -25,7 +25,7 @@ void main() async {
 
   group('Topicが存在するとき', () {
     testWidgets('Topicが指定されているとき、編集ページが表示されていること', (WidgetTester tester) async {
-      Topic('Summary', 'Memo', '', null, null).save();
+      await Topic('Summary', 'Memo', '', null, null).save();
       var index = 0;
 
       await tester.pumpWidget(wrapWithMaterial(TopicPage(index: index)));


### PR DESCRIPTION
TopicをHiveObjectを拡張する形に変更します。
Topic.boxが名前被りでうまくないのでとりあえずbox2()という名前にします。

## なぜ
どうしてHiveObjectを使いたかったかというと、keyを取得できるからです。
今まではこれがなくて、取得も削除も位置の変わってしまうindexを指定していました。
keyがあれば、位置に依存しないで取得も削除もできるようになります。